### PR TITLE
Move Tezos to the latest-release branch

### DIFF
--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -8,7 +8,7 @@ class Tezos < Formula
   desc "Platform for distributed consensus with meta-consensus capability"
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :revision => "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090", :branch => "latest-release", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :revision => "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090", :tag => "v7.2", :shallow => false
 
   version "7.2"
 

--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -10,9 +10,9 @@ class Tezos < Formula
 
   # url "https://gitlab.com/tezos/tezos.git", :revision => "64c855499057fa84b41fcb9f3d7d72d4570db1a7", :branch => "mainnet", :shallow => false
 
-  url "https://gitlab.com/tezos/tezos.git", :revision => "51977265590ba5fbd166b921e265fa22bf9f66a6", :branch => "latest-release", :shallow => false
-  
-  version "007_multinetwork"
+  url "https://gitlab.com/tezos/tezos.git", :revision => "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090", :branch => "latest-release", :shallow => false
+
+  version "7.2-release"
 
   head "https://gitlab.com/tezos/tezos.git", :branch => "v7-release"
 

--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -16,7 +16,7 @@ class Tezos < Formula
     root_url "https://bintray.com/michaeljklein/bottles-tq"
     cellar :any
     rebuild 1
-    sha256 "dac4ee6d43ea671f504283c6d497cfc241b5c166d896a52288fa2f311e443618" => :catalina
+    sha256 "eda8424a2e1f56f3dcaa75680f475747cd898ee3546c09b182062d42f474c9de" => :catalina
   end
 
   depends_on "opam" => :build

--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -8,17 +8,15 @@ class Tezos < Formula
   desc "Platform for distributed consensus with meta-consensus capability"
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :revision => "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090", :tag => "v7.2", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v7.2", :shallow => false
 
   version "7.2"
-
-  head "https://gitlab.com/tezos/tezos.git", :branch => "v7-release"
 
   bottle do
     root_url "https://bintray.com/michaeljklein/bottles-tq"
     cellar :any
     rebuild 1
-    sha256 "213e9a5d5907a4c00f666967b8a83e48cbfee12cbce2139dd408b0177dd9b09a" => :catalina
+    sha256 "dac4ee6d43ea671f504283c6d497cfc241b5c166d896a52288fa2f311e443618" => :catalina
   end
 
   depends_on "opam" => :build

--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -10,7 +10,7 @@ class Tezos < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :revision => "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090", :branch => "latest-release", :shallow => false
 
-  version "7.2-release"
+  version "7.2"
 
   head "https://gitlab.com/tezos/tezos.git", :branch => "v7-release"
 

--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -8,17 +8,20 @@ class Tezos < Formula
   desc "Platform for distributed consensus with meta-consensus capability"
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :revision => "64c855499057fa84b41fcb9f3d7d72d4570db1a7", :branch => "mainnet", :shallow => false
-  version "006_PsCARTHA"
+  # url "https://gitlab.com/tezos/tezos.git", :revision => "64c855499057fa84b41fcb9f3d7d72d4570db1a7", :branch => "mainnet", :shallow => false
 
-  head "https://gitlab.com/tezos/tezos.git", :branch => "carthagenet"
+  url "https://gitlab.com/tezos/tezos.git", :revision => "51977265590ba5fbd166b921e265fa22bf9f66a6", :branch => "latest-release", :shallow => false
+  
+  version "007_multinetwork"
 
-  bottle do
-    root_url "https://dl.bintray.com/michaeljklein/bottles-tq"
-    cellar :any
-    sha256 "a804b682b3038693302b0116dbe8ddc8646c089456b0911318ae289022615626" => :catalina
-    sha256 "3ec8358445f73441f58fd11d4eeeb20eaedae749bb085df99cbc67ae99456ad9" => :x86_64_linux
-  end
+  head "https://gitlab.com/tezos/tezos.git", :branch => "v7-release"
+
+  # bottle do
+  #   root_url "https://dl.bintray.com/michaeljklein/bottles-tq"
+  #   cellar :any
+  #   sha256 "a804b682b3038693302b0116dbe8ddc8646c089456b0911318ae289022615626" => :catalina
+  #   sha256 "3ec8358445f73441f58fd11d4eeeb20eaedae749bb085df99cbc67ae99456ad9" => :x86_64_linux
+  # end
 
   depends_on "opam" => :build
 

--- a/Formula/tezos.rb
+++ b/Formula/tezos.rb
@@ -8,20 +8,18 @@ class Tezos < Formula
   desc "Platform for distributed consensus with meta-consensus capability"
   homepage "https://gitlab.com/tezos/tezos"
 
-  # url "https://gitlab.com/tezos/tezos.git", :revision => "64c855499057fa84b41fcb9f3d7d72d4570db1a7", :branch => "mainnet", :shallow => false
-
   url "https://gitlab.com/tezos/tezos.git", :revision => "51977265590ba5fbd166b921e265fa22bf9f66a6", :branch => "latest-release", :shallow => false
-  
+
   version "007_multinetwork"
 
   head "https://gitlab.com/tezos/tezos.git", :branch => "v7-release"
 
-  # bottle do
-  #   root_url "https://dl.bintray.com/michaeljklein/bottles-tq"
-  #   cellar :any
-  #   sha256 "a804b682b3038693302b0116dbe8ddc8646c089456b0911318ae289022615626" => :catalina
-  #   sha256 "3ec8358445f73441f58fd11d4eeeb20eaedae749bb085df99cbc67ae99456ad9" => :x86_64_linux
-  # end
+  bottle do
+    root_url "https://bintray.com/michaeljklein/bottles-tq"
+    cellar :any
+    rebuild 1
+    sha256 "213e9a5d5907a4c00f666967b8a83e48cbfee12cbce2139dd408b0177dd9b09a" => :catalina
+  end
 
   depends_on "opam" => :build
 


### PR DESCRIPTION
Also remove the botttle. I'm not intimately familiar with ruby, but
that seems to work and generate the binaries.